### PR TITLE
Change displayed name in test harness

### DIFF
--- a/src/templates/generate-config.py
+++ b/src/templates/generate-config.py
@@ -47,6 +47,7 @@ def list_test_executions(example_apps, test_suites):
     new_example = {
       'example-app-path': app_path, 'test-suite-name': suite_name, 
       'example-app-name': app_name, 'test-suite-path': suite_path, 
+      'name': F'{app_name} ({suite_name} test suite)'
     }
     test_executions.append({F"test-example": new_example})
   return test_executions


### PR DESCRIPTION
Currently during test execution circleCi display for configurations are:  -test-example-1
-test-example-2
...
This PR changes it to format: 
-app_name (test_config test suite)