### PR TITLE
hotfix deleteion of /tags in chekout step

### DIFF
--- a/src/templates/base-generated-config.yaml
+++ b/src/templates/base-generated-config.yaml
@@ -24,7 +24,7 @@ jobs:
             # Clone repository into a temporary directory and switch to the specified tag
             git clone . temp_repo
             cd temp_repo
-            git checkout tags/<< parameters.bb-version >>
+            git checkout << parameters.bb-version >>
 
             if [ ! -d "<< parameters.test-suite-path >>" ]; then
               mkdir -p << parameters.test-suite-path >>


### PR DESCRIPTION
As part of this ticket, I've removed the "tags/" option from the checkout command to allow for the inclusion of the "main" branch when selecting a version.